### PR TITLE
Update BASE URL for easy implementation in CCE Server

### DIFF
--- a/Build/_config.yml
+++ b/Build/_config.yml
@@ -22,7 +22,7 @@ email: YOUR EMAIL
 description: >-
   Dieses Buch soll als Skript zur Ingeneursinformatik Verlesung 2020 an der Bergischen Universität Wuppertal dienen.
 
-baseurl: /Vorlesung_Ingenieurinformatik/
+baseurl: 
 url: https://lu-kas.github.io
 
 


### PR DESCRIPTION
BASE URL should be updated, so that the webpage can internally be reached from root url!