### PR TITLE
korrektur 0323_referenzen

### DIFF
--- a/Content/Script/03_datenanalyse/0323_referenzen.ipynb
+++ b/Content/Script/03_datenanalyse/0323_referenzen.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 1,
    "metadata": {
     "tags": [
      "hide_input"
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -82,12 +82,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Wird nun auf den Teilbereich zugegriffen, wird auch das Original verändert, da die Variable `bereich` nur eine Referenz, d.h. ein Zeiger oder Hinweis, auf eine andere Position ist."
+    "Wird nun eine Änderung im Teilbereich durchgeführt, wird auch das Original verändert, da des Array `bereich` die selben Elemente referenziert wie das Array `original`. Konkret bedeutet dies, dass beide Arrays an der gleichen Stelle im Speicher nach ihren Elementen schauen und wird dort ein Wert verändert, ist dies immer für beide sichtbar."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -106,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -136,12 +136,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Es ist nicht möglich direkt abzulesen ob eine Variable als Referenz auf einen (Teil eines) Arrays verweist. Einig mit der Funktion `np.shares_memory` ist eine Überlappung des addressierten Speicherbereichs abfragbar. Ist diese Überlappung gegeben, so zeigen beide Variablen auf gleiche (Teil-) Bereiche. "
+    "Es ist nicht möglich, direkt abzulesen, ob zwei Arrays den gleichen Speicherplatz referenzieren. Mit der Funktion `np.shares_memory` ist jedoch eine Überlappung des addressierten Speicherbereichs abfragbar."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -165,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -192,12 +192,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Soll auf dem Indexbereich gearbeitet werden und dabei die Werte verändert werden können ohne das Original zu ändern, muss eine Kopie erstellt werden. Dazu kann die `np.copy`-Funktion verwendet werden."
+    "Soll auf einem Indexbereich gearbeitet werden, ohne gleichzeitig die Elemente das Originals zu ändern, muss eine Kopie der Daten genutzt werden. Dazu existiert die `np.copy`-Funktion, die genau eine solche Kopie erstellt."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -215,7 +215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -223,7 +223,7 @@
      "output_type": "stream",
      "text": [
       "[  5.   6.   7. -12. -12. -12. -12. -12.  13.  14.]\n",
-      "[0. 0. 0. 0. 0.]\n"
+      "[-12. -12. -12. -12. -12.]\n"
      ]
     }
    ],
@@ -234,7 +234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -264,7 +264,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Der Vorteil von Referenzen ist, dass unnötige Kopien nicht gemacht werden müssen. Insbesondere bei großen Datenmengen wird so der Speicher- und Rechenbedarf deutlich reduziert."
+    "Der Vorteil von Referenzen ist, dass unnötige Kopien verhindert werden. Soll beispielsweise ein Teil eines Datensatzes visualisiert werden, ist es oft überflüssig, eine Kopie der Daten zu erstellen. Insbesondere bei großen Datenmengen wird so der Speicher- und Rechenbedarf deutlich reduziert."
    ]
   },
   {
@@ -283,7 +283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -305,7 +305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -330,7 +330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -356,7 +356,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -380,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -433,7 +433,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/Content/Script/03_datenanalyse/0323_referenzen.ipynb
+++ b/Content/Script/03_datenanalyse/0323_referenzen.ipynb
@@ -82,7 +82,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Wird nun eine Änderung im Teilbereich durchgeführt, wird auch das Original verändert, da des Array `bereich` die selben Elemente referenziert wie das Array `original`. Konkret bedeutet dies, dass beide Arrays an der gleichen Stelle im Speicher nach ihren Elementen schauen und wird dort ein Wert verändert, ist dies immer für beide sichtbar."
+    "Wird nun eine Änderung im Teilbereich durchgeführt, wird auch das Original verändert, da das Array `bereich` dieselben Elemente referenziert wie das Array `original`. Konkret bedeutet dies, dass beide Arrays an der gleichen Stelle im Speicher nach ihren Elementen schauen und wird dort ein Wert verändert, ist dies immer für beide sichtbar."
    ]
   },
   {
@@ -192,7 +192,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Soll auf einem Indexbereich gearbeitet werden, ohne gleichzeitig die Elemente das Originals zu ändern, muss eine Kopie der Daten genutzt werden. Dazu existiert die `np.copy`-Funktion, die genau eine solche Kopie erstellt."
+    "Soll auf einem Indexbereich gearbeitet werden, ohne gleichzeitig die Elemente des Originals zu ändern, muss eine Kopie der Daten genutzt werden. Dazu existiert die `np.copy`-Funktion, die genau eine solche Kopie erstellt."
    ]
   },
   {


### PR DESCRIPTION
ich glaube es ist falsch, einen slice eines arrays referenz zu nennen, da es ein eigenes objekt mit eigener id ist und nur ein teil der zugehörigen daten, explizit die elemente des arrays, den gleichen speicherplatz wie das original belegen. dies ist mein vorschlag.