### PR TITLE
korrektur l2 norm

### DIFF
--- a/Content/Script/03_datenanalyse/033_modellierung.ipynb
+++ b/Content/Script/03_datenanalyse/033_modellierung.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "Als Abstandmaß zwischen einer Modellfunktion und den Messpunkten kann die [L2-Norm](https://de.wikipedia.org/wiki/Folgenraum#lp) verwendet werden. Diese ist definiert als\n",
     "\n",
-    "$$ \\sf || y(x) - (x_i, y_i) ||_2 = \\sum_{i=1}^n \\left(y(x_i) - y_i\\right)^2 \\quad .$$\n",
+    "$$ \\sf || y(x) - (x_i, y_i) ||_2 = \\sqrt{\\sum_{i=1}^n \\left(y(x_i) - y_i\\right)^2} \\quad .$$\n",
     "\n",
     "Eine solche Norm gibt ein Maß für die Qualität einer Approximation: je kleiner der Abstand, desto besser die Qualität. Dies ermöglicht das Finden optimaler Koeffizienten und  wird beispielsweise in der Methode der kleinsten Quadrate genutzt, in der ein Satz an Koeffizienten gesucht wird, der die L2-Norm minimiert."
    ]


### PR DESCRIPTION
muss nicht eine wurzel um die summe in der l2 norm?